### PR TITLE
removing duplicate code in upload tab

### DIFF
--- a/app/create_excel.py
+++ b/app/create_excel.py
@@ -8,6 +8,11 @@ from tempfile import NamedTemporaryFile
 import openpyxl
 
 def create_excel_fun(keywords, list_taxa_id, all_strain_data):
+    """
+    keywords: NCBI Taxonomy Ids of taxa with exact match to a NCBI Taxonomy Id
+    list_taxa_id: names of the taxa with exact NCBI Taxonomy ids
+    all_strain_data: list of dictionaries with taxa without an exact NCBI Taxonomy Id
+    """
 
     wb = openpyxl.load_workbook('templates/metadata_template.xlsx')
     sheet = wb['COMMUNITY_MEMBERS']
@@ -25,11 +30,15 @@ def create_excel_fun(keywords, list_taxa_id, all_strain_data):
     if all_strain_data:
 
         for i, dic in enumerate(all_strain_data):
-            name = dic.get(f'name_{i}', '')
+
+            index = dic["case_number"]
+            name = dic.get(f'name_{index}', '')
+
             if name is None or name == "":
                 continue
-            description = dic.get(f'description_{i}', '')
-            parent_ncbi_tax_id = dic.get(f'parent_taxon_id_{i}')
+
+            description = dic.get(f'description_{index}', '')
+            parent_ncbi_tax_id = dic.get(f'parent_taxon_id_{index}')
 
             sheet.cell(row=k+i+2, column=1, value=f'member_{k+i+1}')
             sheet.cell(row=k+i+2, column=2, value=0)

--- a/app/create_excel.py
+++ b/app/create_excel.py
@@ -32,13 +32,13 @@ def create_excel_fun(keywords, list_taxa_id, all_strain_data):
         for i, dic in enumerate(all_strain_data):
 
             index = dic["case_number"]
-            name = dic.get(f'name_{index}', '')
+            name = dic.get('name', '')
 
             if name is None or name == "":
                 continue
 
-            description = dic.get(f'description_{index}', '')
-            parent_ncbi_tax_id = dic.get(f'parent_taxon_id_{index}')
+            description = dic.get('description', '')
+            parent_ncbi_tax_id = dic.get('parent_taxon_id')
 
             sheet.cell(row=k+i+2, column=1, value=f'member_{k+i+1}')
             sheet.cell(row=k+i+2, column=2, value=0)

--- a/app/pages/2_Upload Data.py
+++ b/app/pages/2_Upload Data.py
@@ -439,8 +439,6 @@ def tab_step2():
             save_all = st.button('Save All', type='primary')
             if save_all:
 
-                print("all_strain_data", all_strain_data)
-
                 # Check if there are strains that do have exact NCBI Taxonomy ids.
                 if len(keywords) > 0:
                     df_taxonomy = taxonomy_df_for_taxa_list(keywords, conn)
@@ -459,6 +457,7 @@ def tab_step2():
                         other_taxa_list.append(taxa_id)
                         all_strain_data.append(strain)
 
+                print("\n=======\n New round with: ")
                 print("keywords:", keywords)
                 print("list_taxa_id:", list_taxa_id)
                 print("other_taxa_list", other_taxa_list)
@@ -474,9 +473,17 @@ def tab_step3(keywords, list_taxa_id, all_strain_data):
     Step 3: Download templates tab
     """
     with tab3:
+
         colu1,  colu2 = st.columns(2)
+
         if st.session_state['verify'] == 1:
+
             with colu1:
+
+                """
+                RAW DATA TEMPLATE
+                """
+
                 st.subheader("1. Download the Data Template")
                 st.markdown(
                     """
@@ -547,16 +554,16 @@ def tab_step3(keywords, list_taxa_id, all_strain_data):
                         cheb_id = filtered_df.iloc[0]['cheb_id']
                         st.info(f'For more information about **{i}** go to [{cheb_id}](https://www.ebi.ac.uk/chebi/searchId.do?chebiId={cheb_id})', icon="❕")
 
+                # [NOTE] Keep
                 all_keywords = []
                 for case in all_strain_data:
                     if "case_number" in case:
                         index = case["case_number"]
                         check = f'parent_taxon_{index}'
                         if check in case:
-                            name = case[f'parent_taxon_{index}']
-                            tax_id = case[f"parent_taxon_id_{index}"]
+                            # parent_name = case[f'parent_taxon_{index}']
+                            name = case[f'name_{index}']
                             all_keywords.append(name)
-                            # all_keywords.append(tax_id)
 
                 if len(all_keywords) > 0:
                     all_keywords.extend(keywords)

--- a/app/pages/2_Upload Data.py
+++ b/app/pages/2_Upload Data.py
@@ -75,7 +75,7 @@ def get_highest_index(all_strain_data):
     indices = []
     try:
         for index, strain in enumerate(all_strain_data):
-            if f"parent_taxon_id_{index + 1}" in strain:
+            if "parent_taxon_id" in strain:
                 indices.append(index + 1)
     except:
         indices.append(1)
@@ -115,18 +115,18 @@ def display_strain_row(index):
                     '*Name of the microbial strain:',
                     placeholder='1. Provide a name to the microbial strain',
                     help='Complete with the name of your microbial strain that does not match to an existing NCBI Taxonomy Id.',
-                    key=f'other_name{index}'
+                    key=f'other_name_{index}'
                 )
-                row_strain_data[f'name_{index}'] = other_name
+                row_strain_data['name'] = other_name
 
             with col2_add:
                 other_description = st.text_input(
                     '*Description of the microbial strain:',
                     placeholder='2. Provide an informative desciption of the microbial strain',
                     help='Complete with a description of your microbial strain',
-                    key=f'other_description{index}'
+                    key=f'other_description_{index}'
                 )
-                row_strain_data[f'description_{index}'] = other_description
+                row_strain_data['description'] = other_description
 
             # Columns for taxa with NCBI Tax Id available
             col3_add, col4_add, col6_add= st.columns([0.39, 0.39, 0.10])
@@ -135,7 +135,7 @@ def display_strain_row(index):
                     '*Search microbial strain species:',
                     placeholder='3. Search microbial strain species',
                     help='Type the specific microbial strain  species, then press enter',
-                    key=f'input_other_taxa{index}'
+                    key=f'input_other_taxa_{index}'
                 )
 
             with col4_add:
@@ -148,7 +148,7 @@ def display_strain_row(index):
                         index=None,
                         placeholder="4. Select one of the species below",
                         help='Select only one microbial strain species, then click on add',
-                        key=f'other_taxonomy{index}'
+                        key=f'other_taxonomy_{index}'
                     )
                     if other_taxonomy is not None:
                         if other_name == "":
@@ -157,13 +157,15 @@ def display_strain_row(index):
                             st.warning("Please make sure you provide a description to before you continue.")
 
                         row_strain_data["case_number"] = index
-                        row_strain_data[f'parent_taxon_{index}'] = other_taxonomy
-                        row_strain_data[f'parent_taxon_id_{index}'] = df_other_taxonomy[df_other_taxonomy["tax_names"] == other_taxonomy]["tax_id"].item()
+                        row_strain_data['parent_taxon'] = other_taxonomy
+                        row_strain_data['parent_taxon_id'] = df_other_taxonomy[
+                            df_other_taxonomy["tax_names"] == other_taxonomy
+                            ]["tax_id"].item()
 
                         parent_strains_df = taxonomy_df_for_taxa_list([other_taxonomy], conn)
                         strains_df = parent_strains_df[ parent_strains_df['tax_names'] == other_taxonomy ]
                         taxa_id = strains_df.iloc[0]['tax_id']
-                        row_strain_data[f'parent_taxon_id_{index}'] = taxa_id
+                        row_strain_data['parent_taxon_id'] = taxa_id
 
                         st.info(
                             f'For more information about **{other_taxonomy}** go to the \
@@ -449,11 +451,11 @@ def tab_step2():
 
                 for index, strain in enumerate(all_strain_data_del_in,  start=1):
 
-                    if f'parent_taxon_id_{index}' not in strain:
+                    if 'parent_taxon_id' not in strain:
                         continue
 
                     if st.session_state['rows_communities'][index]:
-                        taxa_id =  strain[f'parent_taxon_id_{index}']
+                        taxa_id =  strain['parent_taxon_id']
                         other_taxa_list.append(taxa_id)
                         all_strain_data.append(strain)
 
@@ -558,11 +560,11 @@ def tab_step3(keywords, list_taxa_id, all_strain_data):
                 all_keywords = []
                 for case in all_strain_data:
                     if "case_number" in case:
-                        index = case["case_number"]
-                        check = f'parent_taxon_{index}'
+                        # index = case["case_number"]
+                        check = 'parent_taxon'
                         if check in case:
-                            # parent_name = case[f'parent_taxon_{index}']
-                            name = case[f'name_{index}']
+                            # parent_name = case['parent_taxon']
+                            name = case['name']
                             all_keywords.append(name)
 
                 if len(all_keywords) > 0:


### PR DESCRIPTION
Aim of this PR is to:

- remove the duplicate code related to the `display_strain_row()` function 
- make it independent from `{index}` 
- fix the `delete` buttons to remove the entry/row they correspond to 


